### PR TITLE
Fix RSS feed title, description, and link

### DIFF
--- a/src/main/jbake/jbake.properties
+++ b/src/main/jbake/jbake.properties
@@ -26,6 +26,7 @@ render.archive=false
 archive.file=archive.html
 render.tags=false
 tag.path=tags
-site.host=http://jbake.org
+# site.host is used by the RSS feed
+site.host=https://opennlp.apache.org
 template.news.file=news.ftl
 #db.store=local

--- a/src/main/jbake/templates/feed.ftl
+++ b/src/main/jbake/templates/feed.ftl
@@ -19,11 +19,11 @@
 -->
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>JBake</title>
+    <title>Apache OpenNLP</title>
     <link>${config.site_host}</link>
     <atom:link href="${config.site_host}/feed.xml" rel="self" type="application/rss+xml" />
-    <description>JBake - Java based open source static site/blog generator for developers</description>
-    <language>en-gb</language>
+    <description>The Apache OpenNLP library is a machine learning based toolkit for the processing of natural language text</description>
+    <language>en-us</language>
     <pubDate>${published_date?string("EEE, d MMM yyyy HH:mm:ss Z")}</pubDate>
     <lastBuildDate>${published_date?string("EEE, d MMM yyyy HH:mm:ss Z")}</lastBuildDate>
 


### PR DESCRIPTION
Our RSS feed is displaying the title as JBake, as well as description and the link too. This pull request fixes all these items.