### PR TITLE
OPENNLP-1067: Use variables in jbake.properties file to specify version used in site generation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
           <dependency>
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj</artifactId>
-            <version>1.5.4.1</version>
+            <version>1.5.5</version>
           </dependency>
 
         </dependencies>

--- a/src/main/jbake/content/docs/index.ad
+++ b/src/main/jbake/content/docs/index.ad
@@ -25,13 +25,13 @@
 There exists a manual and Javadoc API documentation for Apache OpenNLP. The manual
 explains how the various OpenNLP components can be used and trained.
 
-### Apache OpenNLP 1.8.0 documentation
+### Apache OpenNLP {opennlp_version} documentation
 
-* link:/docs/1.8.0/manual/opennlp.html[Apache OpenNLP Manual]
-* link:/docs/1.8.0/apidocs/opennlp-tools/index.html[Apache OpenNLP Tools Javadoc]
-* link:/docs/1.8.0/apidocs/opennlp-uima/index.html[Apache OpenNLP UIMA Javadoc]
-* link:/docs/1.8.0/apidocs/opennlp-brat-annotator/index.html[Apache OpenNLP BRAT Annotator Javadoc]
-* link:/docs/1.8.0/apidocs/opennlp-morfologik-addon/index.html[Apache OpenNLP Morfologik Addon Javadoc]
+* link:/docs/{opennlp_version}/manual/opennlp.html[Apache OpenNLP Manual]
+* link:/docs/{opennlp_version}/apidocs/opennlp-tools/index.html[Apache OpenNLP Tools Javadoc]
+* link:/docs/{opennlp_version}/apidocs/opennlp-uima/index.html[Apache OpenNLP UIMA Javadoc]
+* link:/docs/{opennlp_version}/apidocs/opennlp-brat-annotator/index.html[Apache OpenNLP BRAT Annotator Javadoc]
+* link:/docs/{opennlp_version}/apidocs/opennlp-morfologik-addon/index.html[Apache OpenNLP Morfologik Addon Javadoc]
 
 Note: All the documentation is also included in the binary distribution.
 

--- a/src/main/jbake/content/download.ad
+++ b/src/main/jbake/content/download.ad
@@ -24,31 +24,31 @@
 
 ## Last Official Release
 
-Apache OpenNLP 1.8.0 is now available for download.
+Apache OpenNLP {opennlp_version} is now available for download.
 
 [options="header"]
 |===
 |File | Signatures
 
-|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.tar.gz[apache-opennlp-1.8.0-bin.tar.gz]
-|https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.tar.gz.md5[md5]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.tar.gz.sha1[sha1]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.tar.gz.asc[asc]
+|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.tar.gz[apache-opennlp-{opennlp_version}-bin.tar.gz]
+|https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.tar.gz.md5[md5]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.tar.gz.sha1[sha1]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.tar.gz.asc[asc]
 
-|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.zip[apache-opennlp-1.8.0-bin.zip]
-|https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.zip.md5[md5]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.zip.sha1[sha1]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-bin.zip.asc[asc]
+|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.zip[apache-opennlp-{opennlp_version}-bin.zip]
+|https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.zip.md5[md5]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.zip.sha1[sha1]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-bin.zip.asc[asc]
 
-|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.tar.gz[apache-opennlp-1.8.0-src.tar.gz]
-|https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.tar.gz.md5[md5]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.tar.gz.sha1[sha1]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.tar.gz.asc[asc]
+|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.tar.gz[apache-opennlp-{opennlp_version}-src.tar.gz]
+|https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.tar.gz.md5[md5]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.tar.gz.sha1[sha1]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.tar.gz.asc[asc]
 
-|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.zip[apache-opennlp-1.8.0-src.zip]
-|https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.zip.md5[md5]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.zip.sha1[sha1]
-https://www.apache.org/dist/opennlp/opennlp-1.8.0/apache-opennlp-1.8.0-src.zip.asc[asc]
+|https://www.apache.org/dyn/closer.cgi/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.zip[apache-opennlp-{opennlp_version}-src.zip]
+|https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.zip.md5[md5]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.zip.sha1[sha1]
+https://www.apache.org/dist/opennlp/opennlp-{opennlp_version}/apache-opennlp-{opennlp_version}-src.zip.asc[asc]
 |===
 
 Note: Please note that the tar.gz archive contain file names longer than 100 characters and has
@@ -76,7 +76,7 @@ be found https://www.apache.org/dev/release-signing.html[here].
 
 ## Models
 The models over at SourceForge for 1.5.0 can be http://opennlp.sourceforge.net/models-1.5/[found here]
-and are fully compatible with Apache OpenNLP 1.8.0.
+and are fully compatible with Apache OpenNLP {opennlp_version}.
 
 The models can be used for testing or getting started, please train your own models for all other use cases.
 

--- a/src/main/jbake/content/maven-dependency.ad
+++ b/src/main/jbake/content/maven-dependency.ad
@@ -22,7 +22,6 @@
 :jbake-status: published
 :idprefix:
 
-
 Apache OpenNLP is also distributed via the Maven Central Repository and
 the maven artifacts are located http://repo1.maven.org/maven2/org/apache/opennlp/[here].
 
@@ -35,59 +34,75 @@ all transient dependencies are resolved automatically.
 
 To use the OpenNLP Tools define the following dependency:
 
-
-    <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-tools</artifactId>
-      <version>1.7.2</version>
-    </dependency>
-
+[source,xml,indent=0,subs=attributes+]
+----
+<dependency>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-tools</artifactId>
+  <version>{opennlp_version}</version>
+</dependency>
+----
 
 ## OpenNLP UIMA Annotators Dependency
 
 To use the OpenNLP UIMA Annotators define the following dependency:
 
-    <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-uima</artifactId>
-      <version>1.7.2</version>
-    </dependency>
+[source,xml,indent=0,subs=attributes+]
+----
+<dependency>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-uima</artifactId>
+  <version>{opennlp_version}</version>
+</dependency>
+----
 
 ## OpenNLP Morfologik AddOn Dependency
 
 To use the OpenNLP Morfologik-Addon define the following dependency:
 
-    <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-morfologik-addon</artifactId>
-      <version>1.7.2</version>
-    </dependency>
+[source,xml,indent=0,subs=attributes+]
+----
+<dependency>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-morfologik-addon</artifactId>
+  <version>{opennlp_version}</version>
+</dependency>
+----
 
 ## OpenNLP Brat Annotator Dependency
 
 To use the OpenNLP UIMA Annotators define the following dependency:
 
-    <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-brat-annotator</artifactId>
-      <version>1.7.2</version>
-    </dependency>
+[source,xml,indent=0,subs=attributes+]
+----
+<dependency>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-brat-annotator</artifactId>
+  <version>{opennlp_version}</version>
+</dependency>
+----
 
 ## OpenNLP Tools SNAPSHOT Dependency
 
 To use the current trunk version define the following dependency:
 
-    <dependency>
-      <groupId>org.apache.opennlp</groupId>
-      <artifactId>opennlp-tools</artifactId>
-      <version>1.7.3-SNAPSHOT</version>
-    </dependency>
+[source,xml,indent=0,subs=attributes+]
+----
+<dependency>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-tools</artifactId>
+  <version>{opennlp_next_version}</version>
+</dependency>
+----
 
 The SNAPSHOT dependency requires the following repository:
 
-    <repositories>
-      <repository>
-        <id>apache opennlp snapshot</id>
-        <url>https://repository.apache.org/content/repositories/snapshots/</url>
-      </repository>
-    </repositories>
+[source,xml,indent=0,subs=attributes+]
+----
+<repositories>
+  <repository>
+    <id>apache opennlp snapshot</id>
+    <url>https://repository.apache.org/content/repositories/snapshots/</url>
+  </repository>
+</repositories>
+----

--- a/src/main/jbake/jbake.properties
+++ b/src/main/jbake/jbake.properties
@@ -30,3 +30,7 @@ tag.path=tags
 site.host=https://opennlp.apache.org
 template.news.file=news.ftl
 #db.store=local
+asciidoctor.attributes.export=true
+asciidoctor.attributes.export.prefix=
+opennlp.version=1.8.0
+opennlp.next.version=1.8.1-SNAPSHOT


### PR DESCRIPTION
We cannot use pom.xml, as the feature in the JBake maven plug-in was released with the jbake-maven-plugin 0.2.0. The plug-in was released in GitHub (i.e. tagged), however, never released to Maven Central (see https://github.com/ingenieux/jbake-maven-plugin/issues/18).

For now we can use jbake.properties. Better than manually changing the value in several places :-)

Notice the manual URL is set to 1.7.2, as we do not have the manual generated for 1.8.0 - TBH I do not know how to generate it. And that we have a property for the next version, as we have an example SNAPSHOT usage for OpenNLP Tools module - not sure if we really need that...

Cheers
Bruno