### PR TITLE
OPENNLP-1114: ascii syntax, typo and minor adjustments

### DIFF
--- a/src/main/jbake/content/release.ad
+++ b/src/main/jbake/content/release.ad
@@ -23,12 +23,14 @@
 :idprefix:
 
 ## One time setup
+
 - Make sure you have your PGP key entered into https://id.apache.org/.
   Your KEYS will then be present in: https://people.apache.org/keys/group/opennlp.asc
-- Check if you have your PGP keys password.
-- Create a maven settings.xml to publish to repository.apache.org
+- Check if you have your PGP keys password
+- Create a maven `settings.xml` to publish to `repository.apache.org`
 
 ## Step-by-Step
+
 The following documents the steps which are necessary to make a
 release of Apache OpenNLP.
 
@@ -37,50 +39,50 @@ release of Apache OpenNLP.
 - Prepare Jira for the release
 - Crate an empty test plan for the release
 - Make a release candidate
-- Test the candidate accoding to the test plan and iterate until tests pass
-- Do the release vote on opennlp-dev and on general incubator
+- Test the candidate according to the test plan and iterate until tests pass
+- Call the release vote on opennlp-dev and on general incubator
 
 ## Releasing
 
 The release candidate can be released after a successful release vote on
 the opennlp-dev and incubator general list.
 
-- Release the staging repository. This will make the artifacts available in the Maven Central repository.
-To do this go to the http://repository.apache.org[repository server], log in, go to the staging area and release the staging repository linked to this release.
-- Upload artifacts to the distribution server. All release artifacts need to be copied to `/www/www.apache.org/dist/opennlp` on `people.apache.org`.
-- On Opennlp-site github repo
-
-   -update the properties {opennlp.version} and {opennlp.next.version} in jbake.properties
-   -Add the following lines at the beginning of docs/legacy.ad
-  ----
-  ### Apache OpenNLP ${previous.release} documentation
-  * link:/docs/${previous.release}/manual/opennlp.html[Apache OpenNLP Manual]
-  * link:/docs/${previous.release}/apidocs/opennlp-tools/index.html[Apache OpenNLP Tools Javadoc]
-  * link:/docs/${previous.release}/apidocs/opennlp-uima/index.html[Apache OpenNLP UIMA Javadoc]
-  * link:/docs/${previous.release}/apidocs/opennlp-brat-annotator/index.html[Apache OpenNLP BRAT Annotator Javadoc]
-  * link:/docs/${previous.release}/apidocs/opennlp-morfologik-addon/index.html[Apache OpenNLP Morfologik Addon Javadoc]
-  ----
-
-   -Add the following to main/pom.xml
-  [source,xml,indent=0,subs=attributes+]
-  ----
-  <artifactItem>
-    <groupId>org.apache.opennlp</groupId>
-    <artifactId>opennlp-distr</artifactId>
-    <version>${project.version}</version>
-    <overWrite>false</overWrite>
-    <type>zip</type>
-    <classifier>bin</classifier>
-    <outputDirectory>${project.build.directory}/distr/1.8.1</outputDirectory>
-  </artifactItem>
-  ----
-
-   -Add a news item in news/release-{xyz}.ad by copying the content from OpenNLP project opennlp-distr/src/README
-
-- Rebuild opennlp-site and redeploy the site (if Automatic Buildbot doesn't kick in)
-- Test and review the website. Test that all download links are working. Test that the documentation is updated and can be viewed.
-- Send out announcements to announce@apache.org, dev@opennlp.apache.org, users@opennlp.apache.org
-- Close out the present release in Jira.
+* Release the staging repository. This will make the artifacts available in the Maven Central repository
+To do this go to the http://repository.apache.org[repository server], log in, go to the staging area and release the staging repository linked to this release
+* Upload artifacts to the distribution server. All release artifacts need to be copied to `/www/www.apache.org/dist/opennlp` on `people.apache.org`
+* On opennlp-site GitHub repository
+** Update the properties `{opennlp.version}` and `{opennlp.next.version}` in `jbake.properties`
+** Add the following lines at the beginning of `docs/legacy.ad`
++
+----
+### Apache OpenNLP ${previous.release} documentation
+* link:/docs/${previous.release}/manual/opennlp.html[Apache OpenNLP Manual]
+* link:/docs/${previous.release}/apidocs/opennlp-tools/index.html[Apache OpenNLP Tools Javadoc]
+* link:/docs/${previous.release}/apidocs/opennlp-uima/index.html[Apache OpenNLP UIMA Javadoc]
+* link:/docs/${previous.release}/apidocs/opennlp-brat-annotator/index.html[Apache OpenNLP BRAT Annotator Javadoc]
+* link:/docs/${previous.release}/apidocs/opennlp-morfologik-addon/index.html[Apache OpenNLP Morfologik Addon Javadoc]
+----
+** Add the following to main/pom.xml
++
+[source,xml,indent=0,subs=attributes+]
+----
+<artifactItem>
+  <groupId>org.apache.opennlp</groupId>
+  <artifactId>opennlp-distr</artifactId>
+  <version>${project.version}</version>
+  <overWrite>false</overWrite>
+  <type>zip</type>
+  <classifier>bin</classifier>
+  <outputDirectory>${project.build.directory}/distr/1.8.1</outputDirectory>
+</artifactItem>
+----
+** Add a news item in `news/release-{xyz}.ad` by copying the content from OpenNLP project `opennlp-distr/src/README`
+* Rebuild opennlp-site and redeploy the site (if Automatic Buildbot doesn't kick in)
+* Test and review the website. Test that all download links are working. Test that the documentation is updated and can be viewed
+* Send out announcements to announce@apache.org, dev@opennlp.apache.org, users@opennlp.apache.org
+* Close out the present release in Jira
 
 It is suggested to use the wiki to plan all tasks for the release
 and to distribute them among the team.
+
+


### PR DESCRIPTION
Hope it's all right to hijack OPENNLP-1114 for this PR. If not let me know. I will have time in between retrospective meetings tomorrow, and can open a new ticket/PR.

This PR updates the asciidoc file, to use a nested lists syntax with 2 *'s for second level list. Also uses the + symbol to indicate list item continuation.

There is at one typo fixed (s/accoding/according). Headers have an extra blank line before so that rendering in GitHub while browsing the code works (note: aware we are not using GitHub, but since it makes no difference for asciidoc and the final HTML, but also allows better displaying in GitHub, I think it's OK?).

Tried to make it concise the use of dot/period at the end of list items (i.e. no dot).

Preview of what is looks like.

![release-preview-fullpage](https://user-images.githubusercontent.com/304786/28247350-8b19c560-6a82-11e7-832a-4c2151041fd1.png)

ps: there's still one mention to 1.8.1 in the document. Is that OK? Should it be mentioned when it needs to change?