### PR TITLE
[OPENNLP-1327] Add .asf.yaml file

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,9 @@
+github:
+  description: "Website sources for the Apache OpenNLP website"
+  homepage: https://opennlp.apache.org/
+  labels:
+    - apache
+    - opennlp
+    - jbake
+    - website
+


### PR DESCRIPTION
Was reading the [infra website](https://infra.apache.org/project-site.html) docs for Apache Sis, when I noticed that in the link they provide for listing projects at ASF using JBake, OpenNLP site did not appear.

Then realized we don't have the `.asf.yaml` file here. I've added it using Apache Jena's as example. That will change the URL of this repository (appears on the right sidebar -->), the description, and topics. Others can change it later via pull requests :+1: 