### PR TITLE
Update outdated faq page to point to recent documentation

### DIFF
--- a/src/main/jbake/content/faq.ad
+++ b/src/main/jbake/content/faq.ad
@@ -38,11 +38,11 @@ https://stackoverflow.com/questions/tagged/opennlp[forums].
   <dd>To train the name finder model you need training data that contains the entities you would
   like to detect.
 Have a look at our manual, in special the sections under the
-<a href="/docs/1.7.2/manual/opennlp.html#tools.namefind.training">Name Finder Training API</a>.
+<a href="/docs/2.1.1/manual/opennlp.html#tools.namefind.training">Name Finder Training API</a>.
 At the beginning of that section you can see how the data has to be marked up. Please note you that you need many sentences to successfully train the name finder.</dd>
 
   <dt>How can I speed up my MaxEnt training time</dt>
-  <dd>Try tweaking the value of <a href="/docs/1.7.2/apidocs/opennlp-tools/opennlp/tools/util/TrainingParameters.html#THREADS_PARAM">TrainingParameters.THREADS_PARAM</a>.</dd>
+  <dd>Try tweaking the value of <a href="/docs/2.1.1/apidocs/opennlp-tools/opennlp/tools/util/TrainingParameters.html#THREADS_PARAM">TrainingParameters.THREADS_PARAM</a>.</dd>
 
   <dt>Will my models trained with a previous version of OpenNLP still work with a newer version?</dt>
   <dd>You should expect it to work. The corpora used is normally the same. However, the behavior may


### PR DESCRIPTION
Change
-
- Update outdated _faq_ page which still referenced 1.7.2 documentation