### PR TITLE
Add ASF Community Code conf banner

### DIFF
--- a/src/main/jbake/templates/footer.ftl
+++ b/src/main/jbake/templates/footer.ftl
@@ -29,6 +29,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
+    <script src="https://www.apachecon.com/event-images/snippet.js"></script>
     <script src="/js/jquery-3.2.1.min.js"></script>
     <script src="/js/bootstrap.min.js"></script>
     <script src="/js/prettify.js"></script>

--- a/src/main/jbake/templates/index.ftl
+++ b/src/main/jbake/templates/index.ftl
@@ -42,6 +42,11 @@
             <p>Learn more about how you can <a href="/get-involved.html">get involved</a>.</p>
         </div>
     </div>
+    <div class="row">
+        <div class="col-lg-12 text-center">
+            <p><a class="acevent" data-format="square" data-mode="dark" data-width="480"></a></p>
+        </div>
+    </div>
 
 </div>
 


### PR DESCRIPTION
Quick patch to add the banner as per instructions at https://www.apachecon.com/event-images/

Looked at archive.org to see where the twitter widget was before, and tried to add a squared logo for the event there.

https://web.archive.org/web/20180311060538/http://opennlp.apache.org/

Preview:

![Screen Shot 2023-08-16 at 18 59 23-fullpage](https://github.com/apache/opennlp-site/assets/304786/48fcdf98-b300-4731-b75e-6573818617bb)
