### PR TITLE
Provide a modern CSS template file for OpenNLP manuals during site build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,13 +146,13 @@
             <phase>process-resources</phase>
             <configuration>
               <target>
+                <!-- 1st phase: Copy and patch files from binary releases -->
                 <ac:for param="folder" xmlns:ac="antlib:net.sf.antcontrib">
                   <dirset dir="target/distr/">
                     <include name="*"/>
                   </dirset>
                   <sequential>
                     <echo>Copy @{folder} docs</echo>
-
                     <copy todir="target/opennlp-site/docs">
                         <fileset dir="@{folder}" casesensitive="yes">
                             <include name="**/docs/**/*"/>
@@ -180,7 +180,19 @@
                     </replaceregexp>
                   </sequential>
                 </ac:for>
-
+                <!-- 2nd phase: modernize some files -->
+                <ac:for param="folder" xmlns:ac="antlib:net.sf.antcontrib">
+                  <dirset dir="target/opennlp-site/docs">
+                    <include name="*"/>
+                  </dirset>
+                  <sequential>
+                    <!-- Replace original CSS file with modern template that supports dark mode -->
+                    <echo>Prepare modern CSS for manual</echo>
+                    <copy file="src/main/templates/docs/css/opennlp-docs.css"
+                          todir="@{folder}/manual/css" overwrite="true">
+                    </copy>
+                  </sequential>
+                </ac:for>
               </target>
             </configuration>
             <goals>
@@ -230,6 +242,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.5.3</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -240,6 +253,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.6.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -250,6 +264,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.7.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -260,6 +275,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.7.1</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -270,6 +286,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.7.2</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -280,6 +297,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.8.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -290,6 +308,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.8.1</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -300,6 +319,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.8.2</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -310,6 +330,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.8.3</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -320,6 +341,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.8.4</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -330,6 +352,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.9.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                <artifactItem>
@@ -340,6 +363,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.9.1</outputDirectory>
+                 <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -350,6 +374,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.9.2</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -360,6 +385,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.9.3</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -370,6 +396,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/1.9.4</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -380,6 +407,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/2.0.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -390,6 +418,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/2.1.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -400,6 +429,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/2.1.1</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -410,6 +440,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/2.2.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
                 <artifactItem>
@@ -420,6 +451,7 @@
                   <type>zip</type>
                   <classifier>bin</classifier>
                   <outputDirectory>${project.build.directory}/distr/2.3.0</outputDirectory>
+                  <excludes>**/lib/**/*</excludes>
                 </artifactItem>
 
               </artifactItems>

--- a/src/main/templates/docs/css/opennlp-docs.css
+++ b/src/main/templates/docs/css/opennlp-docs.css
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+    margin-top: 1em;
+    margin-bottom: 1em;
+    margin-left: 16%;
+    margin-right: 8%
+}
+
+div.legalnotice {
+    max-width: 450px;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        color: #eee;
+        background: #222;
+    }
+    a {
+        color: #A09fff;
+    }
+    h1, h2, h3, h4, div.toc {
+        color: #A09fff;
+    }
+    pre.programlisting, pre.screen, pre.literallayout  {
+        color: #eee;
+        background: #444;
+    }
+    /*
+     * Java syntax highlighting with eclipse default colors
+     * and default font-style
+     */
+    pre.programlisting .hl-keyword {
+        color: #e56b28;
+        font-weight: bold;
+    }
+
+    /* Seems to be broken, override red inline style of hl-string */
+    pre.programlisting .hl-string, pre.programlisting b.hl-string i[style]{
+        color: #f59523 !important;
+    }
+
+    pre.programlisting .hl-tag {
+        color: #3F7F7F;
+    }
+
+    pre.programlisting .hl-comment {
+        color: #3F5F5F;
+        font-style: italic;
+    }
+
+    pre.programlisting .hl-multiline-comment {
+        color: #3F5FBF;
+        font-style: italic;
+    }
+
+    pre.programlisting .hl-value {
+        color: #2A00FF;
+    }
+
+    pre.programlisting .hl-attribute {
+        color: #7F007F;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    h1, h2, h3, h4, div.toc {
+        color: #006699;
+    }
+    pre.programlisting, pre.screen, pre.literallayout {
+        border: 1px dashed #006699;
+        background-color: #EEE;
+    }
+    /*
+     * Java syntax highlighting with eclipse default colors
+     * and default font-style
+     */
+    pre.programlisting .hl-keyword {
+        color: #7F0055;
+        font-weight: bold;
+    }
+
+    /* Seems to be broken, override red inline style of hl-string */
+    pre.programlisting .hl-string, pre.programlisting b.hl-string i[style]{
+        color: #2A00FF !important;
+    }
+
+    pre.programlisting .hl-tag {
+        color: #3F7F7F;
+    }
+
+    pre.programlisting .hl-comment {
+        color: #3F5F5F;
+        font-style: italic;
+    }
+
+    pre.programlisting .hl-multiline-comment {
+        color: #3F5FBF;
+        font-style: italic;
+    }
+
+    pre.programlisting .hl-value {
+        color: #2A00FF;
+    }
+
+    pre.programlisting .hl-attribute {
+        color: #7F007F;
+    }
+}


### PR DESCRIPTION
Change
-

- provides a modern, dark-mode enabled CSS template file for OpenNLP manuals (all versions) as an in-place replacement
- adds required `maven-antrun-plugin` snippet to have the CSS replacement done during site build
- adds excludes declarations to avoid unnecessary libs being unpacked from the binary zip files (->less IO burden!)