### PR TITLE
Polish and update FAQ page

### DIFF
--- a/src/main/jbake/assets/css/custom-style.css
+++ b/src/main/jbake/assets/css/custom-style.css
@@ -35,3 +35,13 @@ body {
 #toc > ul > li > ul {
     padding-inline-start: 1em;
 }
+
+div.qlist.qanda > ol {
+    margin-left: 0;
+    padding-inline-start: 0;
+}
+
+div.qlist.qanda > ol > li {
+    list-style: none;
+    padding-top: .75em;
+}

--- a/src/main/jbake/assets/css/scheme-dark.css
+++ b/src/main/jbake/assets/css/scheme-dark.css
@@ -79,6 +79,11 @@
         color: #f59523;
         background: #222;
     }
+    div.qlist.qanda > ol > li > p:nth-child(1) > em {
+        color: #f59523;
+        background: #222;
+        font-size: 1.2em;
+    }
     .content pre,
     .content pre > code,
     .com, .tag, .pln, .str, .pun, .kwd,

--- a/src/main/jbake/assets/css/scheme-light.css
+++ b/src/main/jbake/assets/css/scheme-light.css
@@ -14,4 +14,8 @@
         border-bottom: 1px solid #e5e5e5;
         background-color: #f5f5f5;
     }
+    div.qlist.qanda > ol > li > p:nth-child(1) > em {
+        color: #832779;
+        font-size: 1.2em;
+    }
 }

--- a/src/main/jbake/content/faq.ad
+++ b/src/main/jbake/content/faq.ad
@@ -23,48 +23,44 @@
 :idprefix:
 
 This list contains common questions asked in link:mailing-lists.html[mailing lists] and
-https://stackoverflow.com/questions/tagged/opennlp[forums,window=_blank].
+link:https://stackoverflow.com/questions/tagged/opennlp[forums,role=external,window=_blank].
 
-++++
-<dl>
+[qanda]
+Where can I download the pre-trained models used in OpenNLP?::
+Models for 23 languages are available at the project's link:/models.html[Models download] page or
+bundled in JAR files distributed via *Maven Central*
+(link:https://central.sonatype.com/search?q=opennlp+models+sentdetect[Sentence-Detector,role=external,window=_blank],
+link:https://central.sonatype.com/search?q=opennlp+models+tokenizer[Tokenization,role=external,window=_blank],
+link:https://central.sonatype.com/search?q=opennlp+models+pos[POS Tagging,role=external,window=_blank]).
 
-  <dt>Where can I download the models used in OpenNLP?</dt>
-  <dd>They are hosted at <a href="https://opennlp.sourceforge.net/models-1.5/" target="_blank">SourceForge</a>.</dd>
-
-  <dt></dt>
-  <dd></dd>
-
-  <dt>How to train a Named Entity Recognition (NER) model?</dt>
-  <dd>To train the name finder model you need training data that contains the entities you would
-  like to detect.
+How to train a Named Entity Recognition (NER) model?::
+To train the name finder model you need training data that contains the entities you would like to detect.
 Have a look at our manual, in special the sections under the
-<a href="/docs/2.2.0/manual/opennlp.html#tools.namefind.training">Name Finder Training API</a>.
-At the beginning of that section you can see how the data has to be marked up. Please note you that you need many sentences to successfully train the name finder.</dd>
+link:https://opennlp.apache.org/docs/{opennlp_version}/manual/opennlp.html#tools.namefind.training[Name Finder Training API,role=external,window=_blank].
+At the beginning of that section you can see how the data has to be marked up. Please note you that you need many sentences to successfully train the name finder.
 
-  <dt>How can I speed up my MaxEnt training time</dt>
-  <dd>Try tweaking the value of <a href="/docs/2.2.0/apidocs/opennlp-tools/opennlp/tools/util/TrainingParameters.html#THREADS_PARAM">TrainingParameters.THREADS_PARAM</a>.</dd>
+How can I speed up the training time of (MaxEnt) models?::
+By default, training runs will be executed _single_-threaded.
+Try tweaking the value of link:https://opennlp.apache.org/docs/{opennlp_version}/apidocs/opennlp-tools/opennlp/tools/util/TrainingParameters.html#THREADS_PARAM[TrainingParameters.THREADS_PARAM,role=external,window=_blank].
+Make sure to set this parameter to match your target environment. A good starting point is to set this to the number of CPU cores available at runtime.
+Please note, however, that only the compute-intensive parts of the training will benefit by tweaking this parameter.
 
-  <dt>Will my models trained with a previous version of OpenNLP still work with a newer version?</dt>
-  <dd>You should expect it to work. The corpora used is normally the same. However, the behavior may
+Will my models trained with a previous version of OpenNLP still work with a newer version?::
+You should expect it to work. The corpora used is normally the same. However, the behavior may
 change when we fix bugs or add new features. The test results in the
-<a href="https://cwiki.apache.org/confluence/display/OPENNLP/Test+Plans">project Wiki</a> may contain useful
-information about model compatibility.</dd>
+link:https://cwiki.apache.org/confluence/display/OPENNLP/Test+Plans[project Wiki,role=external,window=_blank] may contain useful
+information about model compatibility.
 
-  <dt><strong>Is there a commercial license for OpenNLP?</strong></dt>
-  <dd>OpenNLP is licensed under the business-friendly Apache software license,
-version 2.0. You can read the license
-<a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">here</a>
-or <a href="https://en.wikipedia.org/wiki/Apache_License" target="_blank">its Wikipedia page</a>
-for more information.</dd>
+Is there a commercial license for OpenNLP?::
+OpenNLP is licensed under the business-friendly link:https://www.apache.org/licenses/LICENSE-2.0[Apache software license, version 2.0,role=external,window=_blank].
+You can read its link:https://en.wikipedia.org/wiki/Apache_License[Wikipedia,role=external,window=_blank]
+page for more information.
 
-  <dt><strong>How can I start contributing to this project?</strong></dt>
-  <dd>Have a look at our <a href="/get-involved.html">Getting Involved</a> page.
+How can I start contributing to this project?::
+Have a look at our link:/get-involved.html[Getting Involved] page.
 We have a list of issues needing help there, as well as instructions to get started
 contributing to OpenNLP. You may also consider making a
-<a href="https://www.apache.org/foundation/contributing.html" target="_blank">donation to the Apache Software Foundation</a>.</dd>
-
-</dl>
-++++
+link:https://www.apache.org/foundation/contributing.html[donation to the Apache Software Foundation, role=external,window=_blank].
 
 In case you have a suggestion of another question that could be added, please do not hesitate in
 link:/mailing-lists.html[getting in contact].

--- a/src/main/jbake/content/get-involved.ad
+++ b/src/main/jbake/content/get-involved.ad
@@ -21,6 +21,8 @@
 :jbake-tags: download
 :jbake-status: published
 :idprefix:
+:toc: preamble
+:toc-title: Content
 
 The Apache OpenNLP project is developed by volunteers and is always looking for new contributors
 to work on all parts of the project. Every contribution is welcome and needed to make it better.
@@ -66,22 +68,28 @@ This is a great place to meet and get guidance on contributions.
 
 Further details on using the ASF Slack channels and associated expectations can be found at the related https://infra.apache.org/slack.html[ASF infra page].
 
-=== Note
+[NOTE]
 The ASF Slack requires an _@apache.org_ email address to join as a full member. Users without an _@apache.org_ email address have to be invited.
 
 == Making a Contribution
 
-* Create a new issue in the Apache OpenNLP https://issues.apache.org/jira/browse/OPENNLP[JIRA,window=_blank]. Please describe the problem or improvement in the body of the issue. For larger issues, please first contact the developer mailing list and describe the problem.
+* Create a new issue in the Apache OpenNLP link:https://issues.apache.org/jira/browse/OPENNLP[JIRA,window=_blank]. Please describe the problem or improvement in the body of the issue.
 * Next, create a pull request in https://github.com/apache/opennlp/pulls[GitHub,window=_blank].
 
+[NOTE]
+For larger issues, please first contact the developer mailing list and describe the problem.
+
 Bigger contributions can eventually only be accepted when an
-https://apache.org/licenses/icla.pdf[ICLA,window=_blank], https://www.apache.org/licenses/cla-corporate.txt[CCLA,window=_blank]
+link:https://apache.org/licenses/icla.pdf[ICLA,window=_blank], https://www.apache.org/licenses/cla-corporate.txt[CCLA,window=_blank]
 or https://www.apache.org/licenses/software-grant.txt[software grant,window=_blank] is on file.
 
 Contributors who have a history of successful participation are invited to join
-the project as a committer from the https://incubator.apache.org/guides/ppmc.html[PPMC].
+the project as a committer from the link:https://incubator.apache.org/guides/ppmc.html[PPMC,window=_blank].
 
 == Open Tasks
 
-Please see the Apache OpenNLP https://issues.apache.org/jira/browse/OPENNLP[JIRA,window=_blank] for a list of tasks. If you would like to work on a task, please email the developers mailing list and request to do so. You will then be assigned the issue in JIRA.
+Please see the Apache OpenNLP link:https://issues.apache.org/jira/browse/OPENNLP[JIRA,window=_blank] for a list of tasks.
+
+[TIP]
+If you would like to work on a task, please email the developers mailing list and request to do so. You will then be assigned the issue in JIRA.
 

--- a/src/main/jbake/templates/news.ftl
+++ b/src/main/jbake/templates/news.ftl
@@ -24,7 +24,7 @@
 
       <div class="row-fluid marketing">
         <div class="span9">
-          <h2>News</h2>
+          <h1>News</h1>
           <ul>
           	<#list posts as post>
           		<#if (post.status == "published") && (post.category??) && (post.category == "news")>


### PR DESCRIPTION
- polishes the FAQ page
  - switches the source of `faq.ad` to plain AsciiDoc
  - fixes outdated and inconsistent URLs
  - avoids hard-coded version strings improves get-involved.ad for better readability
- adjusts `news.ftl` to start with h1 instead of h2