### PR TITLE
fix: Point privacy link to canonical ASF privacy policy

### DIFF
--- a/src/main/jbake/templates/footer.ftl
+++ b/src/main/jbake/templates/footer.ftl
@@ -22,7 +22,7 @@
             <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a>  <br>
             Apache OpenNLP, OpenNLP, Apache, the Apache logo, and the Apache OpenNLP project logo are
             trademarks of The Apache Software Foundation. -
-            <a href="/privacy-policy.html">Privacy Policy</a></p>
+            <a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></p>
         </div>
     </footer>
 


### PR DESCRIPTION
The existing privacy link pointed to a project-level page. ASF policy requires linking to the canonical privacy policy URL.

Checker: https://whimsy.apache.org/site/